### PR TITLE
Fix Firefox blog-meta th width issue

### DIFF
--- a/assets/css/header.less
+++ b/assets/css/header.less
@@ -42,7 +42,7 @@
     th {
       font-weight: normal;
       text-align: left;
-      max-width: 95px;
+      max-width: 130px;
       overflow: hidden;
       padding: 2px 0px;
     }


### PR DESCRIPTION
FireFox uses .blog-meta table{ max-width:95px;} over /templates/header.php th width=130px, so the organisation th is obscured by the td value. Updating the max-width value resolves the issue.
