### PR TITLE
(fix) removes duplicate ARIA landmark

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -1,4 +1,4 @@
-<header class="header" role="banner">
+<header class="header" aria-label="blog name">
     <div class="grid-row">
 
         <?php $logo_options = get_option('theme_logo_options'); ?>


### PR DESCRIPTION
https://trello.com/c/NCh9Ld6a/11-duplicate-unlabelled-landmarks

Removes one of two `role=“banner”` attributes from the page, leaving in place the one that best matches the [description of the landmark’s use](https://a11yproject.com/posts/aria-landmark-roles/).

Before:
<img width="1215" alt="before" src="https://user-images.githubusercontent.com/822507/65237109-dbabcc00-dad1-11e9-97b3-a0c366ddf2a7.png">

After:
<img width="1211" alt="after" src="https://user-images.githubusercontent.com/822507/65237114-dfd7e980-dad1-11e9-842f-940ad8d8180f.png">
