### PR TITLE
Sidebar and comment heading hierarchy

### DIFF
--- a/templates/sidebar.php
+++ b/templates/sidebar.php
@@ -1,4 +1,5 @@
 <aside class="sidebar" role="complementary">
+  <h2 class="visually-hidden">Related content and links</h2>
   <?php dynamic_sidebar('sidebar') ?>
   <?php if (!is_home()) {
     dynamic_sidebar('page-sidebar');


### PR DESCRIPTION
Trello: https://trello.com/c/7aHoltxN/2-sidebar-and-comment-headings-are-all-h3-making-them-seem-to-be-under-the-last-blog-post-in-the-hierarchy

The sidebar headings and comment headings are all level 3 headings. That puts them under the last level 2 heading of the main content in the hierarchy.

Adding a visually hidden `<h2>` at the top of the sidebar restores the correct hierarchy.

Before:
![blogs-heading-structure](https://user-images.githubusercontent.com/822507/65503714-5ce1d500-debd-11e9-81ab-c41a4e8719d9.png)

After:
<img width="1048" alt="Screenshot 2019-09-24 at 11 15 05" src="https://user-images.githubusercontent.com/822507/65503727-610df280-debd-11e9-9ce8-ebc7a4befd2e.png">

