### PR TITLE
(fix) comments and sharing have a heading

### DIFF
--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -27,6 +27,8 @@
     </footer>
   </article>
 
+  <h2 class="visually-hidden">Sharing and comments</h2>
+
   <nav class="page-numbers-container page-navigation" aria-label="Pagination">
     <div class="previous">
       <?php previous_post_link('%link') ?>


### PR DESCRIPTION
- adds a (visually hidden) h2 ("Sharing and comments") so the comments section headings make hierarchical sense

<img width="404" alt="Screenshot 2019-10-01 at 12 29 56" src="https://user-images.githubusercontent.com/822507/65958544-8cf22080-e447-11e9-986a-b56aec2b84df.png">
