### PR TITLE
Feature/96 Comments headings are subheadings of last heading of page content

### DIFF
--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -27,8 +27,6 @@
     </footer>
   </article>
 
-  <h2 class="visually-hidden">Sharing and comments</h2>
-
   <nav class="page-numbers-container page-navigation" aria-label="Pagination">
     <div class="previous">
       <?php previous_post_link('%link') ?>
@@ -38,6 +36,7 @@
     </div>
   </nav>
 
+  <h2 class="visually-hidden">Sharing and comments</h2>
   <?php share_icons(get_the_ID()) ?>
   <?php comments_template('/templates/comments.php') ?>
 <?php endwhile ?>


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/t9ddsoLf/96-comments-headings-are-subheadings-of-last-heading-of-page-content

## Changes in this PR:
- Move the Sharing and Comments heading below pagination

## Screenshots of UI changes:

### Before
![Screenshot 2019-12-09 at 14 48 26](https://user-images.githubusercontent.com/6421298/70447169-397aff00-1a96-11ea-9a36-dcd20b9f3517.png)


### After
![Screenshot 2019-12-09 at 14 46 36](https://user-images.githubusercontent.com/6421298/70447180-3da71c80-1a96-11ea-8c4a-c08c1a3a8d66.png)

