### PR TITLE
Fix/481 allow wordpress 5.3 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.2] - 2019-12-13
+
+### Added
+- A method to remove the function that Roots hooks onto the 'styler_loader_tag' filter, as this was breaking admin styles in WordPress 5.3 and up.
+
 ## [2.5.1] — 2019-12-12
 
 ### Added

--- a/app/FixRoots.php
+++ b/app/FixRoots.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace GovUKBlogs;
+
+class FixRoots implements \Dxw\Iguana\Registerable
+{
+    public function register()
+    {
+        add_action('init', [$this, 'fixRoots']);
+    }
+
+    public function fixRoots()
+    {
+        remove_filter('style_loader_tag', 'roots_clean_style_tag');
+    }
+}

--- a/app/di.php
+++ b/app/di.php
@@ -1,3 +1,4 @@
 <?php
 
 $registrar->addInstance(new \GovUKBlogs\WidgetCategoriesDropdownWithSubmit\Register());
+$registrar->addInstance(new \GovUKBlogs\FixRoots());

--- a/spec/fix_roots.spec.php
+++ b/spec/fix_roots.spec.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GovUKBlogs;
+
+use \phpmock\mockery\PHPMockery;
+
+describe(FixRoots::class, function () {
+    beforeEach(function () {
+        $this->fixRoots = new FixRoots();
+    });
+
+    afterEach(function () {
+        \Mockery::close();
+    });
+
+    it('is registerable', function () {
+        expect($this->fixRoots)->to->be->instanceof(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('does something', function () {
+            PHPMockery::mock(__NAMESPACE__, 'add_action')->with('init', [$this->fixRoots, 'fixRoots'])->once();
+
+            $this->fixRoots->register();
+        });
+    });
+
+    describe('->fixRoots()', function () {
+        it('removes the filter', function () {
+            PHPMockery::mock(__NAMESPACE__, 'remove_filter')->with('style_loader_tag', 'roots_clean_style_tag')->once();
+
+            $this->fixRoots->fixRoots();
+        });
+    });
+});

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  * Description: This is the beta theme in use for the blogs hosted at blog.gov.uk.
  * License: GNU General Public License v2.0
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 2.5.1
+ * Version: 2.5.2
  *
  * GOV.UK Blogs theme, Copyright (c) 2013 HM Government (Government Digital Service)
  * This theme is distributed under the terms of the GNU GPL, version 2.


### PR DESCRIPTION
This PR removes a filter applied by the "Roots" theme files (included via composer) that breaks admin styling in WordPress 5.3 and up.

Before:  
![2019-12-13-12-22-localhost (1)](https://user-images.githubusercontent.com/370665/70800121-59b30280-1da3-11ea-83c5-78bc8544c35e.png)

After:
![2019-12-13-12-22-localhost](https://user-images.githubusercontent.com/370665/70800162-70595980-1da3-11ea-95d0-5e697ecc482c.png)

