### PR TITLE
Migrate index.php to govuk frontend

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,14 +1,17 @@
-<?php get_template_part('templates/title') ?>
-
 <?php if (!have_posts()) : ?>
-  <div class="alert">
-    <?php _e('Sorry, no results were found.', 'roots') ?>
-  </div>
-  <?php get_search_form() ?>
+    <div class="govuk-error-summary">
+        <h2 class="govuk-error-summary__title">
+          Sorry, no blog posts were found
+        </h2>
+        <p class="govuk-body">This may be because:<p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>No blog posts have yet been published on this blog</li>
+            <li>There is a problem with the service</li>
+        </ul>
+        <p>Please try again later.</p>
+    </div>
 <?php endif ?>
 
 <?php while (have_posts()) : the_post() ?>
-  <?php get_template_part('templates/content', get_post_format()) ?>
+    <?php get_template_part('templates/content', get_post_format()) ?>
 <?php endwhile ?>
-
-<?php get_template_part('templates/pagination') ?>


### PR DESCRIPTION
- Removes includes of partials that don't exist
- Updates the error message that would be displayed on a blog homepage if the blog has no posts, to bring it more inline with "There is a problem with the service" page pattern at https://design-system.service.gov.uk/patterns/problem-with-the-service-pages/ (though also using some of the error styling from https://design-system.service.gov.uk/components/error-summary/).

I'm not aware of a case where the error message part of this template has ever been served, but it could happen if either a) a blog was published with no posts on it; or b) there was some kind of database error when retrieving the posts. So the message should probably be sensible, just in case.

Resolves: https://trello.com/c/2AuPeJXp/500-template-to-migrate-indexphp