### PR TITLE
Don't specify a selection highlight background colour

### DIFF
--- a/assets/css/common/variables.scss
+++ b/assets/css/common/variables.scss
@@ -38,7 +38,6 @@ $buttonHover:darken(govuk-colour("green"), 2); //006435
 $buttonBorder:darken(govuk-colour("green"), 5); //#003618;
 $blogTitleColour: $govuk-secondary-text-colour;
 $placeHolderColour: $govuk-secondary-text-colour;
-$selectionColour:lighten(govuk-colour("green"), 2);
 $tableHeadCellColour: govuk-colour("light-grey");;
 $tableCellColour: #e1e8e8;
 

--- a/assets/css/h5bp.scss
+++ b/assets/css/h5bp.scss
@@ -30,12 +30,10 @@ body {
  */
 
 ::-moz-selection {
-    background: $selectionColour;
     text-shadow: none;
 }
 
 ::selection {
-    background: $selectionColour;
     text-shadow: none;
 }
 


### PR DESCRIPTION
The current selection colour is green, which makes it very hard to read selected text:

![image](https://user-images.githubusercontent.com/1590604/83054672-b13fe480-a04a-11ea-95b1-ff1d213d296c.png)

The default on GOV.UK is to not specify a selected text colour and let the browser decide. 

This PR removes the custom selected text colour. 