### PR TITLE
Use different link text for different URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- "Read more" links include hidden text specifying the post name for screenreader users
+
 ## [3.1.5] - 2020-06-24
 
 ### Changed

--- a/templates/entry-footer.php
+++ b/templates/entry-footer.php
@@ -1,5 +1,5 @@
 <footer class="govuk-body-s">
-  <a class="govuk-link" href="<?php the_permalink() ?>"><strong>Read more</strong> <span class="govuk-visually-hidden">about this topic</span></a>
+  <a class="govuk-link" href="<?php the_permalink() ?>"><strong>Read more</strong> <span class="govuk-visually-hidden">of <?php the_title() ?></span></a>
   <?php if (get_comments_number() != 0) { ?>
       - <a href="<?php comments_link() ?>" class="govuk-link"><?php printf(_n('1 comment', '%1$s comments', get_comments_number(), 'roots'), number_format_i18n(get_comments_number())) ?></a>
     <?php } ?>

--- a/templates/featured.php
+++ b/templates/featured.php
@@ -13,7 +13,7 @@
               <div class="entry-summary">
                 <?php the_excerpt() ?>
               </div>
-              <a class="read-more" href="<?php the_permalink() ?>">Read more <span class="govuk-visually-hidden">about this topic</span></a>
+              <a class="read-more" href="<?php the_permalink() ?>">Read more <span class="govuk-visually-hidden">of <?php the_title() ?></span></a>
             </div>
           </div>
         </article>


### PR DESCRIPTION
Before: all "Read more" links were followed by visually hidden "about this topic" text (as part of the link)

Now: they are followed by "of [post title]" text, which should provide more context for screenreader users.

Resolves: https://trello.com/c/jpF9kdxq/17-the-same-link-text-is-used-for-different-link-targets