### PR TITLE
Fix/13903 ul wrap for archives list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [3.2.1] - 2021-03-10
+
+### Changed
+
+- The "Archives with dropdown" widget wraps its list of archive links in a `<ul>`
+
 
 ## [3.2.0] - 2021-02-16
 

--- a/app/WidgetArchiveDropdownWithSubmit/Widget.php
+++ b/app/WidgetArchiveDropdownWithSubmit/Widget.php
@@ -42,7 +42,7 @@ class Widget extends \WP_Widget
 
         echo '</div>';
 
-        echo '<div class="archive-dropdown-with-submit-js-disabled">';
+        echo '<div class="archive-dropdown-with-submit-js-disabled"><ul>';
 
         wp_get_archives([
             'type' => 'monthly',
@@ -50,7 +50,7 @@ class Widget extends \WP_Widget
             'show_post_count' => true
         ]);
 
-        echo '</div>';
+        echo '</ul></div>';
  
         echo $args['after_widget'];
     }

--- a/spec/widget_archive_dropdown_with_submit/widget.spec.php
+++ b/spec/widget_archive_dropdown_with_submit/widget.spec.php
@@ -67,7 +67,7 @@ describe(Widget::class, function () {
             ], []);
             $output = ob_get_clean();
 
-            expect($output)->to->equal('AAABBBArchivesCCC<div class="archive-dropdown-with-submit-js-enabled"><label class="govuk-visually-hidden" for="y">Archives</label><select class="govuk-select" id="y" name="archive-dropdown"><option value="">Select month</option>HELLO FROM wp_get_archives</select><button class="govuk-button" data-module="govuk-button" onclick="newLocation = document.getElementById(\'y\').value; if ( newLocation != \'\' ) { window.location = newLocation; }">Go</button></div><div class="archive-dropdown-with-submit-js-disabled">HELLO FROM list-format wp_get_archives</div>DDD');
+            expect($output)->to->equal('AAABBBArchivesCCC<div class="archive-dropdown-with-submit-js-enabled"><label class="govuk-visually-hidden" for="y">Archives</label><select class="govuk-select" id="y" name="archive-dropdown"><option value="">Select month</option>HELLO FROM wp_get_archives</select><button class="govuk-button" data-module="govuk-button" onclick="newLocation = document.getElementById(\'y\').value; if ( newLocation != \'\' ) { window.location = newLocation; }">Go</button></div><div class="archive-dropdown-with-submit-js-disabled"><ul>HELLO FROM list-format wp_get_archives</ul></div>DDD');
         });
     });
 });

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  * Description: This is the beta theme in use for the blogs hosted at blog.gov.uk.
  * License: GNU General Public License v2.0
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 3.2.0
+ * Version: 3.2.1
  *
  * GOV.UK Blogs theme, Copyright (c) 2013 HM Government (Government Digital Service)
  * This theme is distributed under the terms of the GNU GPL, version 2.


### PR DESCRIPTION
Before: the list of archive entries displayed by the "Archives widget with dropdown" widget, when javascript is switched off, was not wrapped in a `<ul>`

Now: it is wrapped in a `<ul>`

I've also wrapped the version bump required to release this fix up with this PR.