### PR TITLE
Add nice search urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [3.3.4] - 2022-01-07
+
+- Redirect search results from `/?s=query to /search/query/`
+
 ## [3.3.3] - 2021-11-29
 
 - Fix contrast for cookie consent button 

--- a/app/Theme/NiceSearch.php
+++ b/app/Theme/NiceSearch.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace GovUKBlogs\Theme;
+
+/**
+ * Redirects search results from /?s=query to /search/query/, converts %20 to +
+ *
+ * @link http://txfx.net/wordpress-plugins/nice-search/
+ * @link https://github.com/roots/soil/blob/main/src/Modules/NiceSearchModule.php
+ */
+class NiceSearch implements \Dxw\Iguana\Registerable
+{
+    public function register()
+    {
+        add_filter('template_redirect', [$this, 'redirect']);
+        add_filter('wpseo_json_ld_search_url', [$this, 'rewrite']);
+    }
+
+    /**
+     * Redirect query string search results to pretty URL.
+     */
+    public function redirect()
+    {
+        global $wp_rewrite;
+
+        if (!isset($wp_rewrite) || !is_object($wp_rewrite) || !$wp_rewrite->get_search_permastruct()) {
+            return;
+        }
+
+        $search_base = $wp_rewrite->search_base;
+
+        if (
+            is_search()
+            && strpos($_SERVER['REQUEST_URI'], "/{$search_base}/") === false
+            && strpos($_SERVER['REQUEST_URI'], '&') === false
+        ) {
+            if (wp_redirect(get_search_link())) {
+                exit;
+            }
+        }
+    }
+    /**
+     * Rewrite query string search URL as pretty URL.
+     */
+    public function rewrite(string $url)
+    {
+        return str_replace('/?s=', '/search/', $url);
+    }
+}

--- a/app/di.php
+++ b/app/di.php
@@ -5,3 +5,4 @@ $registrar->addInstance(new \GovUKBlogs\WidgetArchiveDropdownWithSubmit\Register
 $registrar->addInstance(new \GovUKBlogs\FixRoots());
 $registrar->addInstance(new \GovUKBlogs\OpenGraphImage());
 $registrar->addInstance(new \GovUKBlogs\Embed\YouTube());
+$registrar->addInstance(new \GovUKBlogs\Theme\NiceSearch());

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,20 +1,15 @@
 <?xml version="1.0"?>
-<psalm>
-  <projectFiles>
-    <directory name="app"/>
-    <ignoreFiles>
-      <file name="app/load.php"/>
-      <file name="app/di.php"/>
-      <file name="app/FixRoots.php"/>
-      <file name="app/WidgetArchiveDropdownWithSubmit/Register.php"/>
-      <file name="app/WidgetArchiveDropdownWithSubmit/Widget.php"/>
-      <file name="app/WidgetCategoriesDropdownWithSubmit/Register.php"/>
-      <file name="app/WidgetCategoriesDropdownWithSubmit/Widget.php"/>
-      <file name="app/OpenGraphImage.php"/>
-    </ignoreFiles>
-  </projectFiles>
-  <issueHandlers>
-    <!-- WordPress functions are going to be tripping this one constantly -->
-    <UndefinedFunction errorLevel="suppress"/>
-  </issueHandlers>
+<psalm
+    errorLevel="1"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="app" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
 </psalm>

--- a/spec/theme/nice_search.spec.php
+++ b/spec/theme/nice_search.spec.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace GovUKBlogs\Theme;
+
+use \phpmock\mockery\PHPMockery;
+
+describe(NiceSearch::class, function () {
+    beforeEach(function () {
+        $this->niceSearch = new NiceSearch();
+    });
+
+    afterEach(function () {
+        \Mockery::close();
+    });
+
+    it('is registerable', function () {
+        expect($this->niceSearch)->to->be->an->instanceof(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('registers hooks', function () {
+            $addFilter = PHPMockery::mock(__NAMESPACE__, 'add_filter');
+            $addFilter->with('template_redirect', [$this->niceSearch, 'redirect'])->once();
+            $addFilter->with('wpseo_json_ld_search_url', [$this->niceSearch, 'rewrite'])->once();
+
+            $this->niceSearch->register();
+        });
+    });
+
+    describe('->redirect()', function () {
+        context('when $wp_rewrite is not set', function () {
+            it('does nothing', function () {
+                global $wp_rewrite;
+                $wp_rewrite = null;
+
+                $result = $this->niceSearch->redirect();
+                expect($result)->to->equal(null);
+            });
+        });
+
+        context('when $wp_rewrite is not an object', function () {
+            it('does nothing', function () {
+                global $wp_rewrite;
+                $wp_rewrite = [];
+
+                $result = $this->niceSearch->redirect();
+                expect($result)->to->equal(null);
+            });
+        });
+
+        context('when there is no search permalink structure defined', function () {
+            it('does nothing', function () {
+                global $wp_rewrite;
+
+                $wp_rewrite = \Mockery::mock(\WP_Rewrite::class);
+                $wp_rewrite->allows()->get_search_permastruct()->andReturns(false);
+
+                $result = $this->niceSearch->redirect();
+                expect($result)->to->equal(null);
+            });
+        });
+
+        context('when a WP_Rewrite object exists', function () {
+            beforeEach(function () {
+                global $wp_rewrite;
+                $wp_rewrite = \Mockery::mock(\WP_Rewrite::class);
+                $wp_rewrite->allows()->get_search_permastruct()->andReturns(true);
+                $wp_rewrite->search_base = 'search';
+            });
+
+            context('and when not on search results', function () {
+                it('does nothing', function () {
+                    PHPMockery::mock(__NAMESPACE__, 'is_search')->with()->andReturn(false);
+
+                    $result = $this->niceSearch->redirect();
+                    expect($result)->to->equal(null);
+                });
+            });
+
+            context('and when on search results', function () {
+                it('redirects to search permalink', function () {
+                    $_SERVER['REQUEST_URI'] = 'http://foo.bar.invalid/not_search/';
+
+                    PHPMockery::mock(__NAMESPACE__, 'is_search')->andReturn(true);
+                    PHPMockery::mock(__NAMESPACE__, 'wp_redirect')->with('http://foo.bar.invalid/search/query');
+                    PHPMockery::mock(__NAMESPACE__, 'get_search_link')->andReturn('http://foo.bar.invalid/search/query');
+
+                    $this->niceSearch->redirect();
+                });
+            });
+        });
+    });
+
+    describe('->rewrite()', function () {
+        it('rewrites', function () {
+            $url = 'http://foo.bar.invalid/?s=query';
+
+            $result = $this->niceSearch->rewrite($url);
+            expect($result)->to->equal('http://foo.bar.invalid/search/query');
+        });
+    });
+});

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  * Description: This is the beta theme in use for the blogs hosted at blog.gov.uk.
  * License: GNU General Public License v2.0
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 3.3.3
+ * Version: 3.3.4
  *
  * GOV.UK Blogs theme, Copyright (c) 2013 HM Government (Government Digital Service)
  * This theme is distributed under the terms of the GNU GPL, version 2.


### PR DESCRIPTION
This redirects search results from `/?s=query to /search/query/` so that we can better handle DOS attacks through better targeted CloudFront rules.

Compatibility is enabled for Yoast SEO in case the plugin is activated in the future.

@serena-piccioni I would appreciate help with the test writing. In particular, testing the successful redirection and the Yoast compatibility.