### PR TITLE
Chore / update govuk frontend to 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bowser": "^1.9.1",
     "es6-promise": "^4.2.4",
-    "govuk-frontend": "^3.6.0",
+    "govuk-frontend": "^4.0.0",
     "jquery-placeholder": "^2.0.7",
     "url-polyfill": "^1.0.7"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,10 +1166,10 @@ got@^8.3.1:
     url-parse-lax "^3.0.0"
     url-to-options "^1.0.1"
 
-govuk-frontend@^3.6.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.11.0.tgz#5bc38629ec8b290220c2c389dcd664114a045db1"
-  integrity sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg==
+govuk-frontend@^4.0.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
+  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
 
 graceful-fs@^4.1.10, graceful-fs@^4.1.2:
   version "4.2.6"


### PR DESCRIPTION
Updates govuk frontend to 4.0. Part of process to update framework to 5.0. Fixes for any issues caused will feature in subsequent pull requests.