### PR TITLE
Fix / set jquery as dependency

### DIFF
--- a/lib/assets.php
+++ b/lib/assets.php
@@ -5,7 +5,7 @@ add_action('init', function () {
 });
 
 add_action('wp_enqueue_scripts', function () {
-    wp_enqueue_script('main', get_template_directory_uri().'/build/main.min.js');
+    wp_enqueue_script('main', get_template_directory_uri().'/build/main.min.js', ['jquery']);
     wp_enqueue_style('main', get_template_directory_uri().'/build/main.min.css');
 });
 


### PR DESCRIPTION
Sets jquery as dependency when calling JavaScript main file. Previously this was causing console errors and preventing some functionality from working.