### PR TITLE
Chore / remove url polyfill

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,7 +53,6 @@ module.exports = function (grunt) {
                 files: {
                     'build/main.min.js': [
                         'assets/js/plugins/*.js',
-                        'node_modules/url-polyfill/url-polyfill.js',
                         'node_modules/es6-promise/dist/es6-promise.auto.js',
                         'node_modules/govuk-frontend/dist/govuk/all.js',
                         'assets/js/main.js',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "es6-promise": "^4.2.4",
-    "govuk-frontend": "^5.0.0",
-    "url-polyfill": "^1.0.7"
+    "govuk-frontend": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,11 +3196,6 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-polyfill@^1.0.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.12.tgz#6cdaa17f6b022841b3aec0bf8dbd87ac0cd33331"
-  integrity sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A==
-
 url-to-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"


### PR DESCRIPTION
The url polyfill package is intended to provide a polyfill for browsers which do not support the URL interface. However, all modern browsers now support URL https://developer.mozilla.org/en-US/docs/Web/API/URL#browser_compatibility and the package has not been updated in 3 years.