### PR TITLE
Remove pubdate from time

### DIFF
--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -1,5 +1,5 @@
 <div class="govuk-body-s">
-  <?php gds_byline(); ?>, <span class="govuk-visually-hidden">Posted on: </span><time class="updated" datetime="<?php echo get_the_time('c') ?>" pubdate><?php echo get_the_date('j F Y') ?></time>
+  <?php gds_byline(); ?>, <span class="govuk-visually-hidden">Posted on: </span><time class="updated" datetime="<?php echo get_the_time('c') ?>"><?php echo get_the_date('j F Y') ?></time>
   -
   <span class="govuk-visually-hidden">Categories: </span>
   <?php echo get_the_category_list(', ') ?>


### PR DESCRIPTION
This was added over 11 years ago, when the status was more in question, but `pubdate` is not part of the current Whatwg HMTL5 spec for the [time element](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-time-element).