### PR TITLE
Initialise block editor setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add barebones `theme.json` with editor options heavily constrained, in readiness for introduction of GOV.UK design system.
+- Ensure the admin stylesheet is loaded in the Block Editor.
+
+### Changed
+
+- Update theme name and version, to differentiate from (Classic Editor) version 4 of the theme.
+
+### Removed
+
+### Fixed
+
 ## [4.1.0] - 2024-03-14
 
 ### Changed

--- a/app/Theme/Scripts.php
+++ b/app/Theme/Scripts.php
@@ -14,7 +14,7 @@ class Scripts implements \Dxw\Iguana\Registerable
 	public function register()
 	{
 		add_action('wp_enqueue_scripts', [$this, 'wpEnqueueScripts']);
-		add_action('admin_enqueue_scripts', [$this, 'wpEnqueueEditorStyles']);
+		add_action('after_setup_theme', [$this, 'wpEnqueueEditorStyles']);
 		add_action('init', [$this, 'removeRootsScript']);
 		add_filter('wp_script_attributes', [$this, 'addScriptTypeToJs'], 10, 1);
 	}
@@ -23,6 +23,11 @@ class Scripts implements \Dxw\Iguana\Registerable
 	{
 		$newFileName = $this->cssManifest->get($path);
 		return get_template_directory_uri() . '/' . $newFileName;
+	}
+
+	private function getFingerPrintedRelativePath($path)
+	{
+		return $this->cssManifest->get($path);
 	}
 
 	public function removeRootsScript()
@@ -39,7 +44,7 @@ class Scripts implements \Dxw\Iguana\Registerable
 
 	public function wpEnqueueEditorStyles()
 	{
-		wp_enqueue_style('admin', $this->getFingerPrintedPath('build/admin.min.css'));
+		add_editor_style($this->getFingerPrintedRelativePath('build/admin.min.css'));
 	}
 
 	public function addScriptTypeToJs($attr)

--- a/app/Theme/ThemeSupports.php
+++ b/app/Theme/ThemeSupports.php
@@ -6,6 +6,12 @@ class ThemeSupports implements \Dxw\Iguana\Registerable
 {
 	public function register()
 	{
+		add_action('after_setup_theme', [$this, 'addThemeSupport']);
+	}
+
+	public function addThemeSupport()
+	{
+		add_theme_support('editor-styles');
 		add_theme_support('title-tag');
 	}
 }

--- a/spec/theme/scripts.spec.php
+++ b/spec/theme/scripts.spec.php
@@ -21,7 +21,7 @@ describe(GovUKBlogs\Theme\Scripts::class, function () {
 			allow('add_action')->toBeCalled();
 			expect('add_action')->toBeCalled()->times(3);
 			expect('add_action')->toBeCalled()->with('wp_enqueue_scripts', [$this->scripts, 'wpEnqueueScripts']);
-			expect('add_action')->toBeCalled()->with('admin_enqueue_scripts', [$this->scripts, 'wpEnqueueEditorStyles']);
+			expect('add_action')->toBeCalled()->with('after_setup_theme', [$this->scripts, 'wpEnqueueEditorStyles']);
 			expect('add_action')->toBeCalled()->with('init', [$this->scripts, 'removeRootsScript']);
 			allow('get_template_directory_uri')->toBeCalled()->andReturn('/wp-content/themes/theme/templates');
 			allow('add_filter')->toBeCalled();
@@ -50,11 +50,10 @@ describe(GovUKBlogs\Theme\Scripts::class, function () {
 
 	describe('->wpEnqueueEditorStyles()', function () {
 		it('enqueues the editor stylesheet', function () {
-			allow('get_template_directory_uri')->toBeCalled()->andReturn('/wp-content/themes/govuk-blogs');
-			allow('wp_enqueue_style')->toBeCalled();
+			allow('add_editor_style')->toBeCalled();
 			allow($this->cssManifest)->toReceive('get')->andReturn('build/admin.min.1234.css');
 			expect($this->cssManifest)->toReceive('get')->once()->with('build/admin.min.css');
-			expect('wp_enqueue_style')->toBeCalled()->with('admin', '/wp-content/themes/govuk-blogs/build/admin.min.1234.css');
+			expect('add_editor_style')->toBeCalled()->with('build/admin.min.1234.css');
 
 			$this->scripts->wpEnqueueEditorStyles();
 		});

--- a/spec/theme/theme_supports.spec.php
+++ b/spec/theme/theme_supports.spec.php
@@ -10,12 +10,22 @@ describe(GovUKBlogs\Theme\ThemeSupports::class, function () {
 	});
 
 	describe('->register()', function () {
-		it('adds theme support for specified features', function () {
-			allow('add_theme_support')->toBeCalled();
-			expect('add_theme_support')->toBeCalled()->once();
-			expect('add_theme_support')->toBeCalled()->with('title-tag');
+		it('adds the action', function () {
+			allow('add_action')->toBeCalled();
+			expect('add_action')->toBeCalled()->once()->with('after_setup_theme', [$this->themeSupports, 'addThemeSupport']);
 
 			$this->themeSupports->register();
+		});
+	});
+
+	describe('->addThemeSupport()', function () {
+		it('adds theme support for specified features', function () {
+			allow('add_theme_support')->toBeCalled();
+			expect('add_theme_support')->toBeCalled()->times(2);
+			expect('add_theme_support')->toBeCalled()->once()->with('editor-styles');
+			expect('add_theme_support')->toBeCalled()->once()->with('title-tag');
+
+			$this->themeSupports->addThemeSupport();
 		});
 	});
 });

--- a/style.css
+++ b/style.css
@@ -1,11 +1,12 @@
 /*
- * Theme Name: GOV.UK Blogs
+ * Theme Name: GOV.UK Blogs Block Editor theme
  * Author: dxw
- * Author URI: http://dxw.com
- * Description: This is the beta theme in use for the blogs hosted at blog.gov.uk.
+ * Author URI: https://www.dxw.com
+ * Description: This is the Block Editor theme in use for the blogs hosted at blog.gov.uk.
  * License: GNU General Public License v2.0
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: : 4.1.0
+ * Version: 5.0.0
+ * Text Domain: gds-blogs
  *
  * GOV.UK Blogs theme, Copyright (c) 2013 HM Government (Government Digital Service)
  * This theme is distributed under the terms of the GNU GPL, version 2.

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,13 @@
+{
+	"version": 2,
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"settings": {
+		"layout": {
+			"contentSize": "630px",
+			"wideSize": "960px"
+		}
+	},
+	"styles": {},
+	"customTemplates": {},
+	"templateParts": {}
+}

--- a/theme.json
+++ b/theme.json
@@ -2,9 +2,48 @@
 	"version": 2,
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"settings": {
+		"border": {
+			"radius": false,
+			"color": false,
+			"style": false,
+			"width": false
+		},
+		"color": {
+			"custom": false,
+			"customDuotone": false,
+			"customGradient": false,
+			"duotone": [],
+			"gradients": [],
+			"link": false,
+			"palette": [],
+			"text": true,
+			"background": true,
+			"defaultGradients": false,
+			"defaultPalette": false
+		},
+		"custom": {},
 		"layout": {
 			"contentSize": "630px",
 			"wideSize": "960px"
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"blockGap": null,
+			"units": [ "px", "rem" ]
+		},
+		"typography": {
+			"customFontSize": false,
+			"lineHeight": false,
+			"dropCap": false,
+			"fluid": false,
+			"fontStyle": true,
+			"fontWeight": true,
+			"letterSpacing": false,
+			"textDecoration": false,
+			"textTransform": true,
+			"fontSizes": [],
+			"fontFamilies": []
 		}
 	},
 	"styles": {},


### PR DESCRIPTION
## Description

This PR does the initial steps to accommodate basic Block Editor support:

- Update the theme name (and version), to differentiate from (Classic Editor) version 4 of the theme.
- Add barebones `theme.json` with editor options heavily constrained, in readiness for introduction of GOV.UK design system.
- Ensure the _admin_ stylesheet is loaded in the Block Editor.

### Exclusions

- No custom styles are applied to the Block Editor as part of this PR.

## Screenshots

### Before

<img width="1291" alt="Screenshot 2024-03-15 at 11 01 45" src="https://github.com/dxw/govuk-blogs/assets/90315846/5cd2a96e-cafb-460f-a7c4-c3a0e910485a">

### After

<img width="1125" alt="Screenshot 2024-03-15 at 11 00 17" src="https://github.com/dxw/govuk-blogs/assets/90315846/726d286e-ceab-4722-beb9-3f8a04129d88">

## Testing

### Confirm that the Block Editor is working as expected

Assuming you have a Multisite setup:

1. At [the network level](http://localhost/wp-admin/network/settings.php), ensure site admins can change the editor settings.
2. Within the _Writing_ settings of one of the sub-sites, ensure that the Block Editor is the default editor, and users can switch editors.
3. Go to a post admin via the the Block Editor option, and confirm the existing content is contained within a _Classic_ block.
4. Convert the _Classic_ content to blocks, via the _Convert to blocks_ option of that block. Confirm there are no major aesthetic differences.

### Confirm that custom styles are being loaded

1. Append the following CSS to the admin stylesheet (`admin-7815c58399c35222e91caa6c4e5e6be0ff5a817e.min.css`); `* {color: red !important}`.
2. Confirm that all the Block Editor content is red in colour.
