### PR TITLE
Redirect non-atom feeds to /atom

### DIFF
--- a/lib/feeds.php
+++ b/lib/feeds.php
@@ -22,6 +22,14 @@ add_action('init', function () {
 	remove_action('do_feed_rss2', 'do_feed_rss2', 10, 1);
 });
 
+// Redirect non-Atom feeds
+add_action('template_redirect', function () {
+	if (is_feed() && !is_feed('atom')) {
+		wp_redirect(home_url('/feed/atom/'), 302);
+		exit;
+	}
+});
+
 // Do not display comments feed
 add_filter('feed_links_show_comments_feed', function () {
 	return false;


### PR DESCRIPTION
## Description

Related [Trello Card 284](https://trello.com/c/0vUvH1DH/284-gds-blogs-requests-for-feed-rss2-no-longer-working)

Previously, other RSS feeds had been turned off, and it seemed that no measures were put in place to manage the absence of these feeds, leading to a 404 error.

However, a redirect has now been introduced for all non-Atom feeds, providing users with an alternative.
This is a behaviour that happens in other of our sites/themes.

The reasons for their initial deactivation remain unclear to me.

The deactivation occurred in this PR:
https://github.com/dxw/govuk-blogs/pull/13

## How to Test
1. Access the rss2 feeds page: http://localhost/feed/rss2
2. Confirm you are redirected to: http://localhost/feed/