### PR TITLE
Create function to control which blocks are available in the editor.

### DIFF
--- a/app/Blocks/AllowedBlocks.php
+++ b/app/Blocks/AllowedBlocks.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace GovUKBlogs\Blocks;
+
+class AllowedBlocks implements \Dxw\Iguana\Registerable
+{
+	public function register()
+	{
+		add_filter('allowed_block_types_all', [$this, 'limitAllowedBlocks'], 10, 2);
+	}
+
+	public function limitAllowedBlocks($allowed_block_types, $block_editor_context)
+	{
+		if (! empty($block_editor_context->post)) {
+			return [
+				'core/archives',
+				'core/audio',
+				'core/avatar',
+				'core/block',
+				'core/button',
+				'core/buttons',
+				'core/calendar',
+				'core/categories',
+				'core/code',
+				'core/column',
+				'core/columns',
+				'core/cover',
+				'core/embed',
+				'core/file',
+				'core/footnotes',
+				'core/freeform',
+				'core/gallery',
+				'core/group',
+				'core/heading',
+				'core/home-link',
+				'core/html',
+				'core/image',
+				'core/latest-comments',
+				'core/latest-posts',
+				'core/list',
+				'core/list-item',
+				'core/media-text',
+				'core/missing',
+				'core/more',
+				'core/navigation',
+				'core/navigation-link',
+				'core/navigation-submenu',
+				'core/nextpage',
+				'core/page-list',
+				'core/page-list-item',
+				'core/paragraph',
+				'core/pattern',
+				'core/post-author',
+				'core/post-author-biography',
+				'core/post-author-name',
+				'core/post-comments-count',
+				'core/post-comments-form',
+				'core/post-comments-link',
+				'core/post-content',
+				'core/post-date',
+				'core/post-excerpt',
+				'core/post-featured-image',
+				'core/post-navigation-link',
+				'core/post-terms',
+				'core/post-time-to-read',
+				'core/post-title',
+				'core/preformatted',
+				'core/pullquote',
+				'core/query',
+				'core/query-no-results',
+				'core/query-pagination',
+				'core/query-pagination-next',
+				'core/query-pagination-numbers',
+				'core/query-pagination-previous',
+				'core/query-title',
+				'core/quote',
+				'core/read-more',
+				'core/rss',
+				'core/search',
+				'core/separator',
+				'core/shortcode',
+				'core/site-logo',
+				'core/site-tagline',
+				'core/site-title',
+				'core/social-link',
+				'core/social-links',
+				'core/spacer',
+				'core/table',
+				'core/table-of-contents',
+				'core/term-description',
+				'core/video',
+				'govukblogs/accordion',
+				'govukblogs/accordion-row',
+				'govukblogs/details',
+				'govukblogs/inset-text'
+			];
+		}
+
+		return $block_editor_context;
+	}
+}

--- a/app/di.php
+++ b/app/di.php
@@ -8,13 +8,13 @@ $registrar->addInstance(new \Dxw\Iguana\Theme\LayoutRegister(
 
 // Blocks
 $registrar->addInstance(new \GovUKBlogs\Blocks\BlockCategory());
+$registrar->addInstance(new \GovUKBlogs\Blocks\AllowedBlocks());
 $registrar->addInstance(new \GovUKBlogs\Blocks\Details\Block());
 $registrar->addInstance(new \GovUKBlogs\Blocks\InsetText\Block());
 $registrar->addInstance(new \GovUKBlogs\Blocks\Accordion\Block());
 $registrar->addInstance(new \GovUKBlogs\Blocks\AccordionRow\Block());
 
 // Theme
-
 $registrar->addInstance(new \GovUKBlogs\Theme\ThemeSupports());
 $registrar->addInstance(new \GovUKBlogs\WidgetCategoriesDropdownWithSubmit\Register());
 $registrar->addInstance(new \GovUKBlogs\WidgetArchiveDropdownWithSubmit\Register());

--- a/spec/blocks/allowed_blocks.spec.php
+++ b/spec/blocks/allowed_blocks.spec.php
@@ -1,0 +1,37 @@
+<?php
+
+use Kahlan\Plugin\Double;
+
+describe(GovUKBlogs\Blocks\AllowedBlocks::class, function () {
+	beforeEach(function () {
+		$this->allowedBlocks = new GovUKBlogs\Blocks\AllowedBlocks();
+	});
+
+	it('implements \Dxw\Iguana\Registerable', function () {
+		expect($this->allowedBlocks)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+	});
+
+	describe('->register()', function () {
+		it('adds the filter', function () {
+			allow('add_filter')->toBeCalled();
+			expect('add_filter')->toBeCalled()->once()->with('allowed_block_types_all', [$this->allowedBlocks, 'limitAllowedBlocks']);
+
+			$this->allowedBlocks->register();
+		});
+	});
+
+	describe('->limitAllowedBlocks)', function () {
+		it('limits the blocks allowed in the block editor', function () {
+			$arg1 = [
+				'core/post',
+				'core/list'
+			];
+			$arg2 = Double::instance([
+				'class' => '\WP_Block_Editor_Context'
+			]);
+			$result = $this->allowedBlocks->limitAllowedBlocks($arg1, $arg2);
+			expect($result)->toBeA('object');
+			$this->allowedBlocks->limitAllowedBlocks($arg1, $arg2);
+		});
+	});
+});


### PR DESCRIPTION
**Description**

This PR adds a function which allows control over which blocks are allowed in the editor. It includes most blocks in the list be default, but will allow us to remove blocks as required further down the line.

To test: In the block editor check that the available blocks matches the list in the AllowedBlocks class. For example the default Details block is not included in the list - check that it does not appear in the block editor.