### PR TITLE
Enable selection of govuk spacing scale

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -82,7 +82,54 @@
 			"margin": true,
 			"padding": true,
 			"blockGap": null,
-			"units": [ "px", "rem" ]
+			"units": [ "px", "rem" ],
+			"spacingSizes": [
+				{
+					"size": "0.3125rem",
+					"slug": "1",
+					"name": "1"
+				},
+				{
+					"size": "0.625rem",
+					"slug": "2",
+					"name": "2"
+				},
+				{
+					"size": "0.9375rem",
+					"slug": "3",
+					"name": "3"
+				},
+				{
+					"size": "1.25rem",
+					"slug": "4",
+					"name": "4"
+				},
+				{
+					"size": "1.5625rem",
+					"slug": "5",
+					"name": "5"
+				},
+				{
+					"size": "1.875rem",
+					"slug": "6",
+					"name": "6"
+				},
+				{
+					"size": "2.5rem",
+					"slug": "7",
+					"name": "7"
+				},
+				{
+					"size": "3.125rem",
+					"slug": "8",
+					"name": "8"
+				},
+				{
+					"size": "3.75rem",
+					"slug": "9",
+					"name": "9"
+				}
+			]
 		},
 		"typography": {
 			"customFontSize": false,

--- a/theme.json
+++ b/theme.json
@@ -83,6 +83,7 @@
 			"padding": true,
 			"blockGap": null,
 			"units": [ "px", "rem" ],
+			"customSpacingSize": false,
 			"spacingSizes": [
 				{
 					"size": "0.3125rem",

--- a/theme.json
+++ b/theme.json
@@ -100,32 +100,32 @@
 					"name": "3"
 				},
 				{
-					"size": "1.25rem",
+					"size": "clamp(0.9375rem, (100vw - 40rem) * 1000, 1.25rem)",
 					"slug": "4",
 					"name": "4"
 				},
 				{
-					"size": "1.5625rem",
+					"size": "clamp(0.9375rem, (100vw - 40rem) * 1000, 1.5625rem)",
 					"slug": "5",
 					"name": "5"
 				},
 				{
-					"size": "1.875rem",
+					"size": "clamp(1.25rem, (100vw - 40rem) * 1000, 1.875rem)",
 					"slug": "6",
 					"name": "6"
 				},
 				{
-					"size": "2.5rem",
+					"size": "clamp(1.5625rem, (100vw - 40rem) * 1000, 2.5rem)",
 					"slug": "7",
 					"name": "7"
 				},
 				{
-					"size": "3.125rem",
+					"size": "clamp(1.875rem, (100vw - 40rem) * 1000, 3.125rem)",
 					"slug": "8",
 					"name": "8"
 				},
 				{
-					"size": "3.75rem",
+					"size": "clamp(2.5rem, (100vw - 40rem) * 1000, 3.75rem)",
 					"slug": "9",
 					"name": "9"
 				}


### PR DESCRIPTION
## Description

This PR enables selection, within the Block Editor, of spacing values from the GOV.UK spacing scale:

https://design-system.service.gov.uk/styles/spacing/

Although media queries are not supported in `theme.json`, the responsive spacing scale is implemented through [some clever use of CSS `clamp()`](https://css-tricks.com/responsive-layouts-fewer-media-queries/#aa-control-when-the-items-wrap). This enables `theme.json` to handle non-fluid responsive scales, and is particularly useful for spacing because the Block Editor appends inline styles, rather than utility classes (which could have been targeted via custom CSS).

### Exclusions

- This PR just updates the options available to the Block Editor, and does not update any of the default spacing for components.

## Screenshots

<img width="1422" alt="Screenshot 2024-03-26 at 13 43 13" src="https://github.com/dxw/govuk-blogs/assets/90315846/4bb7bce7-2312-4ae4-b295-fbceaa1c8696">

## Testing

1. Add some test content and select a variety of padding sizes from the block settings.
2. With the browser dev tools open on the front-end, confirm that the spacing dimension change in response to the viewport width.