### PR TITLE
Fix/27 ensure no duplicate h1 tags

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,8 +1,8 @@
 <?php if (!have_posts()) : ?>
     <div class="govuk-error-summary">
-        <h2 class="govuk-error-summary__title">
+        <h1 class="govuk-error-summary__title">
           Sorry, no blog posts were found
-        </h2>
+        </h1>
         <p class="govuk-body">This may be because:<p>
         <ul class="govuk-list govuk-list--bullet">
             <li>No blog posts have yet been published on this blog</li>

--- a/templates/404.php
+++ b/templates/404.php
@@ -1,6 +1,6 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-<h2 class="govuk-heading-l">Sorry, but the page you were trying to view does not exist.</h2>
+<h1 class="govuk-heading-l">Sorry, but the page you were trying to view does not exist.</h1>
 
 
 <p class="govuk-body"><?php _e('It looks like this was the result of either:', 'roots'); ?></p>

--- a/templates/archive.php
+++ b/templates/archive.php
@@ -1,6 +1,6 @@
 <?php if (is_category()) : ?>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  <h2 class="govuk-heading-l"><?php single_cat_title(); ?></h2>
+  <h1 class="govuk-heading-l"><?php single_cat_title(); ?></h1>
   <?php echo category_description(); ?>
 <?php endif; ?>
 <?php while (have_posts()) : the_post() ?>

--- a/templates/author.php
+++ b/templates/author.php
@@ -4,7 +4,7 @@
             <?php gds_avatar() ?>
         </div>
         <div class="govuk-grid-column-three-quarters">
-            <h2 class="govuk-heading-l"><?php the_author_meta('display_name'); ?></h2>
+            <h1 class="govuk-heading-l"><?php the_author_meta('display_name'); ?></h1>
             <?php $content = get_the_author_meta('description');
             echo apply_filters('the_content', $content); ?>
         </div>

--- a/templates/header.php
+++ b/templates/header.php
@@ -1,13 +1,17 @@
+<?php
+
+$headerTag = is_home() ? 'h1' : 'div';
+?>
 <header class="header" aria-label="blog name">
     <div class="govuk-grid-row">
 
         <?php $logo_options = get_option('theme_logo_options'); ?>
 
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="blog-title govuk-heading-xl">
+            <<?php echo $headerTag; ?> class="blog-title govuk-heading-xl">
                 <span class="blog"><a href="<?php echo network_site_url(); ?>">Blog</a></span>
                 <a href="<?php echo home_url() ?>"><?php bloginfo('name') ?></a>
-            </h1>
+			</<?php echo $headerTag; ?>>
 
             <?php if ($orgs = gds_organisations() ||  get_option('options_gds_location')) : ?>
                 <div class="bottom blog-meta">

--- a/templates/search.php
+++ b/templates/search.php
@@ -1,5 +1,5 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-<h2 class="govuk-heading-l">Search results for <?php the_search_query(); ?> </h2>
+<h1 class="govuk-heading-l">Search results for <?php the_search_query(); ?> </h1>
 
 <?php if (have_posts()) { ?>
   


### PR DESCRIPTION
Previously, the theme was outputting two sets of h1 tags across a number of pages. This PR changes the markup for the site title to a div on pages on all templates except the home page. The page title is set as h1 instead, across a range of templates.

To test, open any page and check that there is only one h1 tag.