### PR TITLE
Feature / 19695 GA4 migration

### DIFF
--- a/layouts/govuk_template.html
+++ b/layouts/govuk_template.html
@@ -2,6 +2,10 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+	</script>
     <meta charset="utf-8" />
     <title>{{ pageTitle }}</title>
 


### PR DESCRIPTION
Add an function to the template head which allows Google Tag Manager to work correctly if cookies are approved and the GTM script is loaded. Accompanies the changes in the cookie manager plugin here https://github.com/dxw/gds-blogs/pull/86

Zen ticket: https://dxw.zendesk.com/agent/tickets/19695