### PR TITLE
Calls to wp_redirect pass x_directed_by argument

### DIFF
--- a/lib/feeds.php
+++ b/lib/feeds.php
@@ -25,7 +25,7 @@ add_action('init', function () {
 // Redirect non-Atom feeds
 add_action('template_redirect', function () {
 	if (is_feed() && !is_feed('atom')) {
-		wp_redirect(home_url('/feed/atom/'), 302);
+		wp_redirect(home_url('/feed/atom/'), 302, 'govuk-blogs theme');
 		exit;
 	}
 });


### PR DESCRIPTION
When we have incidents or tricky pieces of debugging, it is often useful to know what part of a WordPress system has generated an HTTP redirect. By default, there is some text that apepars 3xx redirect responses which contains the string 'WordPress'. However, it's not usually clear whether this string has been generated by WordPress Core, or by a call to `wp_redirect` in a theme or plugin which uses the default value for the `x_directed_by` argument.

This commit adds an `x_directed_by` argument that is unique to this repository and also a status argument to all calls to `wp_redirect`.

The status argument defaults to 302 (moved temporarily) and including it makes the code a little more self-documenting.

See: https://developer.wordpress.org/reference/functions/wp_redirect/