### PR TITLE
Feature/remove header font weight setting

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -2,6 +2,13 @@
 	"version": 2,
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"settings": {
+		"blocks": {
+			"core/heading": {
+				"typography": {
+					"fontWeight": false
+				}
+			}
+		},
 		"border": {
 			"radius": false,
 			"color": false,


### PR DESCRIPTION
Removes the font weight settings from the Typography > Font Style control on the core header block. As a result headers will always be bold. As per the client request https://docs.google.com/spreadsheets/d/1QYsxRZlHZs7iQWjc8VS3Esj7zgUjAJ5jtBZ6TDypXhw/edit?gid=0#gid=0

To test, add a header block to any page - select typography and font style - you should only see options to change the font style to italic.