### PR TITLE
Remove deprecated WP_Widget()

### DIFF
--- a/lib/about-widget.php
+++ b/lib/about-widget.php
@@ -8,7 +8,7 @@ class AboutWidget extends WP_Widget
 {
 	public function __construct()
 	{
-		$this->WP_Widget('about_widget', 'About Widget', ['classname' => 'about_widget', 'description' => 'Information about blog']);
+		parent::__construct('about_widget', 'About Widget', ['classname' => 'about_widget', 'description' => 'Information about blog']);
 		$this->alt_option_name = 'about_widget';
 	}
 

--- a/lib/feed-email-widget.php
+++ b/lib/feed-email-widget.php
@@ -11,7 +11,7 @@ class FeedEmailWidget extends WP_Widget
 
 	public function __construct()
 	{
-		$this->WP_Widget('feed_email_widget', 'Feed Email Widget', ['classname' => 'feed_email_widget', 'description' => 'Shows feed/email buttons']);
+		parent::__construct('feed_email_widget', 'Feed Email Widget', ['classname' => 'feed_email_widget', 'description' => 'Shows feed/email buttons']);
 		$this->alt_option_name = 'feed_email_widget';
 
 		add_action('save_post', [&$this, 'flush_widget_cache']);


### PR DESCRIPTION
```
PHP Deprecated:  The called constructor method for WP_Widget class in AboutWidget is <strong>deprecated</strong> since version 4.3.0! Use <code>__construct()</code> instead.
PHP Deprecated:  The called constructor method for WP_Widget class in FeedEmailWidget is <strong>deprecated</strong> since version 4.3.0! Use <code>__construct()</code> instead.
```