### PR TITLE
Remove map file from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /govuk_template
 /build/main.min.js.map
 /build/main.min.css.map
+/build/admin.min.css.map
 .DS_Store
 .sass-cache/
 /.php_cs.cache


### PR DESCRIPTION
This file should not be included in version control, as it is unique to the developer machine, in that it includes local file paths.