### PR TITLE
Fix / Co-Authors-Plus error

### DIFF
--- a/lib/byline.php
+++ b/lib/byline.php
@@ -7,7 +7,10 @@ function gds_byline()
   <span class="govuk-visually-hidden">Posted by: </span>
   <?php
   if (function_exists('coauthors_posts_links')) {
-  	coauthors_posts_links(', ');
+  	if (get_the_author()) {
+  		coauthors_posts_links(', ');
+  	}
+
   } else {
   	?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')) ?>" rel="author" class="govuk-link"><?php echo get_the_author() ?></a> <?php
   }


### PR DESCRIPTION
Adds a test to prevent Coauthors Plus function firing if there is no author, as this generates an error. https://github.com/Automattic/Co-Authors-Plus/issues/1066

To test, load a page with no author and check that no errors are logged.