### PR TITLE
Fix / reinstate caption wrapper

### DIFF
--- a/app/Theme/OldRootsCleanup.php
+++ b/app/Theme/OldRootsCleanup.php
@@ -9,6 +9,7 @@ class OldRootsCleanup implements \Dxw\Iguana\Registerable
 		add_filter('excerpt_length', [$this, 'excerptLength']);
 		add_filter('excerpt_more', [$this, 'excerptMore']);
 		add_filter('get_bloginfo_rss', [$this, 'removeDefaultDescription']);
+		add_filter('img_caption_shortcode', [$this, 'gdsCaption'], 10, 3);
 	}
 
 	/**
@@ -31,5 +32,44 @@ class OldRootsCleanup implements \Dxw\Iguana\Registerable
 	{
 		$default_tagline = 'Just another WordPress site';
 		return ($bloginfo === $default_tagline) ? '' : $bloginfo;
+	}
+
+	/**
+	 * Add Bootstrap thumbnail styling to images with captions
+	 * Use <figure> and <figcaption>
+	 *
+	 * @link http://justintadlock.com/archives/2011/07/01/captions-in-wordpress
+	 */
+	public function gdsCaption($output, $attr, $content)
+	{
+		if (is_feed()) {
+			return $output;
+		}
+
+		$defaults = [
+		'id'      => '',
+		'align'   => 'alignnone',
+		'width'   => '',
+		'caption' => ''
+		];
+
+		$attr = shortcode_atts($defaults, $attr);
+
+		// // If the width is less than 1 or there is no caption, return the content wrapped between the [caption] tags
+		if ($attr['width'] < 1 || empty($attr['caption'])) {
+			return $content;
+		}
+
+		// Set up the attributes for the caption <figure>
+		$attributes  = (!empty($attr['id']) ? ' id="' . esc_attr($attr['id']) . '"' : '');
+		$attributes .= ' class="thumbnail wp-caption ' . esc_attr($attr['align']) . '"';
+		$attributes .= ' style="width: ' . esc_attr($attr['width']) . 'px"';
+
+		$output  = '<figure' . $attributes .'>';
+		$output .= do_shortcode($content);
+		$output .= '<figcaption class="caption wp-caption-text">' . $attr['caption'] . '</figcaption>';
+		$output .= '</figure>';
+
+		return $output;
 	}
 }

--- a/spec/theme/old_roots_cleanup.spec.php
+++ b/spec/theme/old_roots_cleanup.spec.php
@@ -12,10 +12,11 @@ describe(GovUKBlogs\Theme\OldRootsCleanup::class, function () {
 	describe('->register()', function () {
 		it('adds the filters', function () {
 			allow('add_filter')->toBeCalled();
-			expect('add_filter')->toBeCalled()->times(3);
+			expect('add_filter')->toBeCalled()->times(4);
 			expect('add_filter')->toBeCalled()->with('excerpt_length', [$this->oldRootsCleanup, 'excerptLength']);
 			expect('add_filter')->toBeCalled()->with('excerpt_more', [$this->oldRootsCleanup, 'excerptMore']);
 			expect('add_filter')->toBeCalled()->with('get_bloginfo_rss', [$this->oldRootsCleanup, 'removeDefaultDescription']);
+			expect('add_filter')->toBeCalled()->with('img_caption_shortcode', [$this->oldRootsCleanup, 'gdsCaption']);
 
 			$this->oldRootsCleanup->register();
 		});
@@ -37,6 +38,52 @@ describe(GovUKBlogs\Theme\OldRootsCleanup::class, function () {
 			$more = 'Read more';
 			$value = $this->oldRootsCleanup->excerptMore($more);
 			expect($value)->toEqual(' &hellip; <a href="' . 'http://localhost.com' . '">' . 'Continued' . '</a>');
+		});
+	});
+
+	describe('->gdsCaption()', function () {
+		beforeEach(function () {
+			$this->output = 'a string';
+			$this->attr = [
+				'id' => '0',
+				'align' => 'none',
+				'width'   => 0,
+				'caption' => ''
+			];
+			$this->content = 'the content';
+		});
+		context('the page is a feed', function () {
+			it('returns the original string', function () {
+				allow('is_feed')->toBeCalled()->andReturn(true);
+				$result = $this->oldRootsCleanup->gdsCaption($this->output, $this->attr, $this->content);
+				expect($result)->toEqual('a string');
+			});
+		});
+		context('there is no caption and image width', function () {
+			it('returns the content', function () {
+				allow('is_feed')->toBeCalled()->andReturn(false);
+				allow('shortcode_atts')->toBeCalled()->andReturn($this->attr);
+				$result = $this->oldRootsCleanup->gdsCaption($this->output, $this->attr, $this->content);
+				expect($result)->toEqual('the content');
+			});
+		});
+		context('there is an image with a caption', function () {
+			it('returns a custom string', function () {
+				$this->attr = [
+					'id' => '0',
+					'align' => 'none',
+					'width'   => '10',
+					'caption' => 'a caption'
+				];
+				allow('is_feed')->toBeCalled()->andReturn(false);
+				allow('shortcode_atts')->toBeCalled()->andReturn($this->attr);
+				allow('esc_attr')->toBeCalled()->andReturn('0');
+				allow('esc_attr')->toBeCalled()->andReturn('none');
+				allow('esc_attr')->toBeCalled()->andReturn('10');
+				allow('do_shortcode')->toBeCalled()->with('the content')->andReturn('the content');
+				$result = $this->oldRootsCleanup->gdsCaption($this->output, $this->attr, $this->content);
+				expect($result)->toEqual('<figure class="thumbnail wp-caption 10" style="width: 10px">the content<figcaption class="caption wp-caption-text">a caption</figcaption></figure>');
+			});
 		});
 	});
 });


### PR DESCRIPTION
Reintroduce old Roots function which wrapped images with captions with figure markup. Removing it has caused some old images to break their container. See this GhostInspector test: https://app.ghostinspector.com/tests/596ce914afa86562a175123d

To test, add an image via the classic editor block eg using something like:
`[caption id="attachment_63" align="aligncenter" width="744"]<a href="https://gds.blog.staging.gds.dalmatian.dxw.net/wp-content/uploads/sites/60/2011/02/openlylocal1.jpg"><img class="size-full wp-image-63" title="openlylocal" src="https://gds.blog.staging.gds.dalmatian.dxw.net/wp-content/uploads/sites/60/2011/02/openlylocal1.jpg" alt="" width="744" height="436" /></a> Screenshot of http://openlylocal.com[/caption]`

Check that the image doesn't break the container.