### PR TITLE
Don't check get_the_author()

### DIFF
--- a/lib/byline.php
+++ b/lib/byline.php
@@ -4,14 +4,11 @@
 function gds_byline()
 {
 	?>
-  <span class="govuk-visually-hidden">Posted by: </span>
-  <?php
-  if (function_exists('coauthors_posts_links')) {
-  	if (get_the_author()) {
-  		coauthors_posts_links(', ');
-  	}
-
-  } else {
-  	?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')) ?>" rel="author" class="govuk-link"><?php echo get_the_author() ?></a> <?php
-  }
+	<span class="govuk-visually-hidden">Posted by: </span>
+	<?php
+	if (function_exists('coauthors_posts_links')) {
+		coauthors_posts_links(', ');
+	} else {
+		?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')) ?>" rel="author" class="govuk-link"><?php echo get_the_author() ?></a> <?php
+	}
 }


### PR DESCRIPTION
If a post has no wordpress owner, but has an guest author, a check of `get_the_author()` will fail.

https://dxw.zendesk.com/agent/tickets/20385