### PR TITLE
Fix/escape character in regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.1] - 2024-12-12
+
+### Fixed
+
+- PHP Warning about unrecognized character in Instagram regex
+
 ## [6.0.0] - 2024-12-12
 
 ### Added

--- a/lib/embed.php
+++ b/lib/embed.php
@@ -6,7 +6,7 @@
 
 # Instagram: add class so Instagram embeds can be styled independently
 add_filter('embed_oembed_html', function ($cache, $url, $attr, $post_ID) {
-	if (preg_match('/https?:\/\/www\.\instagram\.com/', $url) == 1) {
+	if (preg_match('/https?:\/\/www\.instagram\.com/', $url) == 1) {
 		$cache = str_replace('<div class="entry-content-asset">', '<div class="entry-content-asset instagram-embed">', $cache);
 	} elseif (preg_match('/https?:\/\/twitter\.com/', $url) == 1) {
 		$cache = str_replace('<div class="entry-content-asset">', '<div class="entry-content-asset twitter-embed">', $cache);

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  * Description: This is the Block Editor theme in use for the blogs hosted at blog.gov.uk.
  * License: GNU General Public License v2.0
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 6.0.0
+ * Version: 6.0.1
  * Text Domain: gds-blogs
  *
  * GOV.UK Blogs theme, Copyright (c) 2013 HM Government (Government Digital Service)


### PR DESCRIPTION
`i` only indicates case insensitivity at the end of a regex, so escaping it here results in a warning in PHP8:

```
PHP message: PHP Warning:  preg_match(): Compilation failed: unrecognized character follows \ at offset 17
```

## How to test

The easiest way to test this is in the PHP interactive shell:

1. Spin up your local GDS blogs instance
1. Access the container with script/console
1. Start a PHP interactive shell with `php -a`
1. `echo preg_match('/https?:\/\/www\.\instagram\.com/', 'https://www.instagram.com');` should produce a compilation failed error
1. `echo preg_match('/https?:\/\/www\.instagram\.com/', 'https://www.instagram.com');` should output 1.