### PR TITLE
If the post_author is a deleted user, change it to a specified user

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -41,3 +41,4 @@ require(__DIR__.'/lib/google-verification-code.php');
 require(__DIR__.'/lib/tiny_mce.php');
 require(__DIR__.'/lib/image-default-link-type.php');
 require(__DIR__.'/lib/feeds.php');
+require(__DIR__.'/lib/set-archive-author.php');

--- a/lib/byline.php
+++ b/lib/byline.php
@@ -4,17 +4,11 @@
 function gds_byline()
 {
 	?>
-	<span class="govuk-visually-hidden">Posted by: </span><?php
-	$tmp_author_id = get_post_field('post_author', $post->ID);
-	$tmp_user =  get_user_by('id', $author_id);
-	if (empty($tmp_user->user_login)) {
-		echo "Deleted user $tmp_author_id";
-		error_log("{$post->ID} has deleted user $tmp_author_id", 0);
+	<span class="govuk-visually-hidden">Posted by: </span>
+	<?php
+	if (function_exists('coauthors_posts_links')) {
+		coauthors_posts_links(', ');
 	} else {
-		if (function_exists('coauthors_posts_links')) {
-			coauthors_posts_links(', ');
-		} else {
-			?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')) ?>" rel="author" class="govuk-link"><?php echo get_the_author() ?></a> <?php
-		}
+		?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')) ?>" rel="author" class="govuk-link"><?php echo get_the_author() ?></a> <?php
 	}
 }

--- a/lib/byline.php
+++ b/lib/byline.php
@@ -4,11 +4,17 @@
 function gds_byline()
 {
 	?>
-	<span class="govuk-visually-hidden">Posted by: </span>
-	<?php
-	if (function_exists('coauthors_posts_links')) {
-		coauthors_posts_links(', ');
+	<span class="govuk-visually-hidden">Posted by: </span><?php
+	$tmp_author_id = get_post_field( 'post_author', $post->ID );
+	$tmp_user =  get_user_by('id', $author_id );
+	if (empty($tmp_user->user_login)) {
+		echo "Deleted user $tmp_author_id";
+		error_log("{$post->ID} has deleted user $tmp_author_id", 0);
 	} else {
-		?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')) ?>" rel="author" class="govuk-link"><?php echo get_the_author() ?></a> <?php
+		if (function_exists('coauthors_posts_links')) {
+			coauthors_posts_links(', ');
+		} else {
+			?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')) ?>" rel="author" class="govuk-link"><?php echo get_the_author() ?></a> <?php
+		}
 	}
 }

--- a/lib/byline.php
+++ b/lib/byline.php
@@ -5,8 +5,8 @@ function gds_byline()
 {
 	?>
 	<span class="govuk-visually-hidden">Posted by: </span><?php
-	$tmp_author_id = get_post_field( 'post_author', $post->ID );
-	$tmp_user =  get_user_by('id', $author_id );
+	$tmp_author_id = get_post_field('post_author', $post->ID);
+	$tmp_user =  get_user_by('id', $author_id);
 	if (empty($tmp_user->user_login)) {
 		echo "Deleted user $tmp_author_id";
 		error_log("{$post->ID} has deleted user $tmp_author_id", 0);

--- a/lib/set-archive-author.php
+++ b/lib/set-archive-author.php
@@ -1,0 +1,16 @@
+<?php
+
+// Set the post_author to be "2"
+
+function set_archive_author($data, $postarr)
+{
+	$fix_types = ["page", "post", "attachment"];
+
+	if (!in_array($data['post_type'], $fix_types)) {
+		return $data;
+	}
+
+	$data['post_author'] = 2;
+
+	return $data;
+}

--- a/lib/set-archive-author.php
+++ b/lib/set-archive-author.php
@@ -11,10 +11,10 @@ function set_archive_author($data, $postarr)
 		return $data;
 	}
 
-	$archive_username = get_option('archive_author');
+	$archive_author = get_option('archive_author');
 
 	if (!empty($archive_author)) {
-		if (is_int($archive_author)) {
+		if ((string)(int)$archive_author == (string)$archive_author) {
 			$archive_author_id = $archive_author;
 		} else {
 			$archive_author_id = get_user_by('id', $archive_author);

--- a/lib/set-archive-author.php
+++ b/lib/set-archive-author.php
@@ -1,6 +1,7 @@
 <?php
 
-// Set the post_author to be "2"
+// Find a username specified in the option "archive_author"
+// Set the post_author (in $data) to be the id corresponding to the user
 
 function set_archive_author($data, $postarr)
 {
@@ -10,7 +11,18 @@ function set_archive_author($data, $postarr)
 		return $data;
 	}
 
-	$data['post_author'] = 2;
+	$archive_username = get_option('archive_author');
+
+	if (!empty($archive_author)) {
+		if (is_int($archive_author)) {
+			$archive_author_id = $archive_author;
+		} else {
+			$archive_author_id = get_user_by('id', $archive_author);
+		}
+		if (!empty($archive_author_id)) {
+			$data['post_author'] = $archive_author_id;
+		}
+	}
 
 	return $data;
 }

--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -6,9 +6,8 @@ if ($check_author_id > 1) {
 	$check_user = get_user_by('id', $check_author_id);
 	if (empty($check_user->user_login)) {
 		error_log("author of post {$post->ID} is deleted user $check_author_id", 0);
-		//add_filter('wp_insert_post_data', 'set_archive_author', 99, 2);
-		//wp_update_post($post);
-		add_filter('wp_footer', 'set_archive_author', 99, 2);
+		add_filter('wp_insert_post_data', 'set_archive_author', 99, 2);
+		wp_update_post($post);
 	}
 }
 

--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -1,13 +1,12 @@
 <div class="govuk-body-s"><?php
 
-// If the post is owned by a deleted user, set it to the archive user
-$tmp_author_id = get_post_field('post_author', $post->ID);
-if ($tmp_author_id > 2) {
-	$tmp_user = get_user_by('id', $tmp_author_id);
-	if (empty($tmp_user->user_login)) {
-		error_log("post {$post->ID} has deleted user $tmp_author_id", 0);
-		add_filter('wp_insert_post_data', 'set_archive_author', '99', 2);
-		wp_update_post($post);
+// If the post is owned by a deleted user, patch it to the archive user
+$check_author_id = get_post_field('post_author', $post->ID);
+if ($check_author_id > 1) {
+	$check_user = get_user_by('id', $check_author_id);
+	if (empty($check_user->user_login)) {
+		error_log("author of post {$post->ID} is deleted user $check_author_id", 0);
+		add_filter('wp_insert_post_data', 'set_archive_author', 99, 2);
 	}
 }
 

--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -6,7 +6,9 @@ if ($check_author_id > 1) {
 	$check_user = get_user_by('id', $check_author_id);
 	if (empty($check_user->user_login)) {
 		error_log("author of post {$post->ID} is deleted user $check_author_id", 0);
-		add_filter('wp_insert_post_data', 'set_archive_author', 99, 2);
+		//add_filter('wp_insert_post_data', 'set_archive_author', 99, 2);
+		//wp_update_post($post);
+		add_filter('wp_footer', 'set_archive_author', 99, 2);
 	}
 }
 

--- a/templates/entry-meta.php
+++ b/templates/entry-meta.php
@@ -1,5 +1,18 @@
-<div class="govuk-body-s">
-  <?php gds_byline(); ?>, <span class="govuk-visually-hidden">Posted on: </span><time class="updated" datetime="<?php echo get_the_time('c') ?>"><?php echo get_the_date('j F Y') ?></time>
+<div class="govuk-body-s"><?php
+
+// If the post is owned by a deleted user, set it to the archive user
+$tmp_author_id = get_post_field('post_author', $post->ID);
+if ($tmp_author_id > 2) {
+	$tmp_user = get_user_by('id', $tmp_author_id);
+	if (empty($tmp_user->user_login)) {
+		error_log("post {$post->ID} has deleted user $tmp_author_id", 0);
+		add_filter('wp_insert_post_data', 'set_archive_author', '99', 2);
+		wp_update_post($post);
+	}
+}
+
+gds_byline();
+?>, <span class="govuk-visually-hidden">Posted on: </span><time class="updated" datetime="<?php echo get_the_time('c') ?>"><?php echo get_the_date('j F Y') ?></time>
   -
   <span class="govuk-visually-hidden">Categories: </span>
   <?php echo get_the_category_list(', ') ?>


### PR DESCRIPTION
Posts having post_author ids that refer to deleted users cause problems - even if co-authors is populated.

In the short term, don't attempt to resolve the author, and independently find posts with

a) deleted authors
b) populated co-authors

and switch them to be an archive user