### PR TITLE
If organisation cannot be looked up return the key

### DIFF
--- a/lib/organisations.php
+++ b/lib/organisations.php
@@ -10,7 +10,11 @@ function gds_organisations()
 
 		if (is_array($field) && count($field) > 0) {
 			foreach ($field as $f) {
-				$output[] = '<a href="'.esc_attr($orgs[$f['organisation']]['web_url']).'">'.esc_html($orgs[$f['organisation']]['title']).'</a>';
+				if (isset($orgs[$f['organisation']])) {
+					$output[] = '<a href="'.esc_attr($orgs[$f['organisation']]['web_url']).'">'.esc_html($orgs[$f['organisation']]['title']).'</a>';
+				} else {
+					$output[] = $f['organisation'];
+				}
 			}
 			return implode(', ', $output);
 		}


### PR DESCRIPTION
The site keeps looking up organisation keys that don't exist.

This happens when blogs were attached to organisations that now no-longer exist

eg https://jonrouse.blog.gov.uk

We should output the key for now, and address this later as a design issue.

```
PHP Warning:  Undefined array key "https://www.gov.uk/api/organisations/department-of-health" in /var/www/html/wp-content/themes/gds-blogs/lib/organisations.php on line 13
```