### PR TITLE
Force unspecified title to be empty string

### DIFF
--- a/lib/about-widget.php
+++ b/lib/about-widget.php
@@ -14,7 +14,7 @@ class AboutWidget extends WP_Widget
 
 	public function widget($args, $instance)
 	{
-		$title   = $instance['title'];
+		$title   = (isset($instance['title'])) ? $instance['title'] : '';
 		$desc    = apply_filters('widget_textarea', empty($instance['description']) ? '' : $instance['description'], $instance);
 
 		// Display information


### PR DESCRIPTION
```
PHP Warning:  Undefined array key "title" in /var/www/html/wp-content/themes/gds-blogs/lib/about-widget.php on line 17
```