### PR TITLE
Remove link to author pages for fallback attribution

### DIFF
--- a/lib/byline.php
+++ b/lib/byline.php
@@ -10,6 +10,6 @@ function gds_byline()
 	if (function_exists('coauthors_posts_links')) {
 		coauthors_posts_links(', ');
 	} else {
-		?> <a href="<?php echo get_author_posts_url(get_the_author_meta('ID')) ?>" rel="author" class="govuk-link"><?php echo get_the_author() ?></a> <?php
+		echo '<i>'. get_the_author() .'</i>';
 	}
 }


### PR DESCRIPTION
It is the intention of GDS that user accounts will be deleted.

Since users aren't tied to specific blogs, there's not elegant way of deleting users that may have posted to different blogs without breaking attribution.

Subequently:

1) We should not be linking to author pages that are tied to login accounts 

2) We should visually indicate that the author attribution is a fallback value