### PR TITLE
Retain co-author data when setting archive author

### DIFF
--- a/app/Theme/FixNonExistentAuthors.php
+++ b/app/Theme/FixNonExistentAuthors.php
@@ -41,9 +41,6 @@ class FixNonExistentAuthors implements \Dxw\Iguana\Registerable
 			}
 			if (!empty($archive_author_id)) {
 				$postData['post_author'] = $archive_author_id;
-				if (taxonomy_exists('author')) {
-					wp_delete_object_term_relationships($postArray['ID'], 'author');
-				}
 			}
 		}
 		return $postData;

--- a/spec/theme/fix_not_existent_authors.spec.php
+++ b/spec/theme/fix_not_existent_authors.spec.php
@@ -101,7 +101,6 @@ describe(\GovUKBlogs\Theme\FixNonExistentAuthors::class, function () {
 			context('and the archive_author option is an integer', function () {
 				it('amends the post data to set the post_author to the archive_author value', function () {
 					allow('get_network_option')->toBeCalled()->andReturn(456);
-					allow('taxonomy_exists')->toBeCalled()->andReturn(false);
 
 					$result = $this->fixNonExistentAuthors->setArchiveAuthor($this->postData, []);
 
@@ -114,7 +113,6 @@ describe(\GovUKBlogs\Theme\FixNonExistentAuthors::class, function () {
 			context('and the archive_author option is a string containing only an integer', function () {
 				it('amends the post data to set the post_author to the archive_author value', function () {
 					allow('get_network_option')->toBeCalled()->andReturn('456');
-					allow('taxonomy_exists')->toBeCalled()->andReturn(false);
 
 					$result = $this->fixNonExistentAuthors->setArchiveAuthor($this->postData, []);
 
@@ -131,21 +129,6 @@ describe(\GovUKBlogs\Theme\FixNonExistentAuthors::class, function () {
 					$result = $this->fixNonExistentAuthors->setArchiveAuthor($this->postData, []);
 
 					expect($result)->toEqual($this->postData);
-				});
-			});
-			context('and the "author" taxonomy exists, indicating that co-authors is in use', function () {
-				it('removes any existing co-author relationships with this post, as well as amending the author ID', function () {
-					allow('get_network_option')->toBeCalled()->andReturn(456);
-					allow('taxonomy_exists')->toBeCalled()->andReturn(true);
-					allow('wp_delete_object_term_relationships')->toBeCalled();
-					expect('wp_delete_object_term_relationships')->toBeCalled()->once()->with(123, 'author');
-
-					$result = $this->fixNonExistentAuthors->setArchiveAuthor($this->postData, ['ID' => 123]);
-
-					expect($result)->toEqual([
-						'post_type' => 'post',
-						'post_author' => 456
-					]);
 				});
 			});
 		});


### PR DESCRIPTION
Before: when we were setting the post author of a post who's post author ID (according to the `author` value in the `wp_posts` table) no longer existed, we also removed any co-authors attributed to that post

Now: we set the author ID in the `wp_posts` table to the archive author ID, but the co-author attribution is retained. This ensures that e.g. attribution for posts where the original user's WordPress user record has been removed, but they still have a co-author profile, is maintained 

## How to test

1. Spin up GDS Blogs, and checkout this branch of the theme
2. Ensure you have the Co-Authors Plus plugin active
3. Ensure you don't have an `archive_author` option set in your `wp_sitemeta`:`wp network meta get 1 archive_author` in WP CLI. If you do, delete it: `wp network meta delete 1 archive_author`
4. Log into WordPress as admin
5. Create a new WordPress user with at least author privileges. Note the ID of this user
6. Create a new Guest Author record
7. Publish a post and attribute it to the new guest author. Note the ID of the post you've just published
8. Update the record for the post you've just published in the `wp_posts` table so that its `post_author` points to a non-existent user ID, e.g. `UPDATE wp_posts SET post_author=999 WHERE ID=[the ID of the post you just published`. You may need to change the table name depending on whether you published the post on a subsite
9. View the post in the frontend. It should still be attributed to the coauthor. Check the author_id in the database: `SELECT post_author FROM wp_posts WHERE ID=[the ID of the post]`. It should still be the non-existent author ID you changed it to
10. Set the archive_author option to the ID of the user you created in step 5: `wp network meta add 1 archive_author [the ID]`
11. Refresh the post in the frontend. It should still be attributed to the coauthor. However, if you check the author_id in the database, it should now point to the `archive_author` value you set