### PR TITLE
Switch inline script to support wp_script_attributes

### DIFF
--- a/app/Theme/ThemeSupports.php
+++ b/app/Theme/ThemeSupports.php
@@ -14,5 +14,6 @@ class ThemeSupports implements \Dxw\Iguana\Registerable
 		add_theme_support('editor-styles');
 		add_theme_support('title-tag');
 		add_theme_support('post-thumbnails');
+		add_theme_support('html5', ['script']);
 	}
 }

--- a/layouts/main.php
+++ b/layouts/main.php
@@ -18,7 +18,7 @@ $govukFrontendAssetPath = get_template_directory_uri() . '/build/node_modules/go
 		<?php wp_head(); ?>
 	</head>
 	<body <?php body_class('govuk-template__body'); ?>>
-   		<script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+		<?php wp_print_inline_script_tag("document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');");?>
 
    		<a href="#content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 		<header role="banner" class="govuk-header" data-module="govuk-header">

--- a/spec/theme/theme_supports.spec.php
+++ b/spec/theme/theme_supports.spec.php
@@ -21,11 +21,11 @@ describe(GovUKBlogs\Theme\ThemeSupports::class, function () {
 	describe('->addThemeSupport()', function () {
 		it('adds theme support for specified features', function () {
 			allow('add_theme_support')->toBeCalled();
-			expect('add_theme_support')->toBeCalled()->times(3);
+			expect('add_theme_support')->toBeCalled()->times(4);
 			expect('add_theme_support')->toBeCalled()->once()->with('editor-styles');
 			expect('add_theme_support')->toBeCalled()->once()->with('title-tag');
 			expect('add_theme_support')->toBeCalled()->once()->with('post-thumbnails');
-
+			expect('add_theme_support')->toBeCalled()->once()->with('html5');
 			$this->themeSupports->addThemeSupport();
 		});
 	});


### PR DESCRIPTION
In order to eventually drop `unsafe-inline` from the `Content-Security-Policy:` we first need to switch all `<script>` tags to the `wp_*_script_tag` methods
introduced in WordPress 5.7.

Note that the main effect here of
  `add_theme_support('html5', ['script']);`
is to drop unnecessary use of `CDATA` wrapping.

https://make.wordpress.org/core/2021/02/23/introducing-script-attributes-related-functions-in-wordpress-5-7/

There should be no (non-whitespace) difference in the output.