### PR TITLE
Fix the Cookie URLs

### DIFF
--- a/templates/cookies.php
+++ b/templates/cookies.php
@@ -1,5 +1,5 @@
 <div class="cookie-message full-width">
-  <p class="govuk-body">
-    GOV.UK blogs use cookies to make the site simpler. <a href="https://blog.gov.uk/cookies/">Find out more about cookies</a>
-  </p>
+	<p class="govuk-body">
+		GOV.UK blogs use cookies to make the site simpler. <a href="https://www.blog.gov.uk/cookies/">Find out more about cookies</a>
+	</p>
 </div>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,9 +1,21 @@
 
-  <ul id="menu-footer" class="govuk-footer__inline-list">
-    <li class="govuk-footer__inline-list-item menu-all-government-blogs"><a class="govuk-footer__link" href="https://www.blog.gov.uk">All GOV.UK blogs</a></li>
-    <li class="govuk-footer__inline-list-item menu-all-government-blog-posts"><a class="govuk-footer__link" href="https://www.blog.gov.uk/all-posts/">All GOV.UK blog posts</a></li>
-    <li class="govuk-footer__inline-list-item menu-gov-uk"><a class="govuk-footer__link" href="https://www.gov.uk">GOV.UK</a></li>
-    <li class="govuk-footer__inline-list-item menu-all-departments"><a class="govuk-footer__link" href="https://www.gov.uk/government/organisations">All departments</a></li>
-    <li class="govuk-footer__inline-list-item menu-a11y"><a class="govuk-footer__link" href="https://www.blog.gov.uk/accessibility-statement/">Accessibility statement</a></li>
-    <li class="govuk-footer__inline-list-item menu-cookies"><a class="govuk-footer__link" href="https://www.blog.gov.uk/cookies">Cookies</a></li>
-  </ul>
+		<ul id="menu-footer" class="govuk-footer__inline-list">
+			<li class="govuk-footer__inline-list-item menu-all-government-blogs">
+				<a class="govuk-footer__link" href="https://www.blog.gov.uk">All GOV.UK blogs</a>
+			</li>
+			<li class="govuk-footer__inline-list-item menu-all-government-blog-posts">
+				<a class="govuk-footer__link" href="https://www.blog.gov.uk/all-posts/">All GOV.UK blog posts</a>
+			</li>
+			<li class="govuk-footer__inline-list-item menu-gov-uk">
+				<a class="govuk-footer__link" href="https://www.gov.uk">GOV.UK</a>
+			</li>
+			<li class="govuk-footer__inline-list-item menu-all-departments">
+				<a class="govuk-footer__link" href="https://www.gov.uk/government/organisations">All departments</a>
+			</li>
+			<li class="govuk-footer__inline-list-item menu-a11y">
+				<a class="govuk-footer__link" href="https://www.blog.gov.uk/accessibility-statement/">Accessibility statement</a>
+			</li>
+			<li class="govuk-footer__inline-list-item menu-cookies">
+				<a class="govuk-footer__link" href="https://www.blog.gov.uk/cookies/">Cookies</a>
+			</li>
+		</ul>


### PR DESCRIPTION
- Correct url for Cookie info
- Whitespace changes, to better match standard GOV.UK