### PR TITLE
Trim manual excerpts to 55 words max

### DIFF
--- a/lib/excerpt.php
+++ b/lib/excerpt.php
@@ -9,3 +9,8 @@ add_action('init', function () {
 add_filter('excerpt_more', function ($more) {
 	return ' …';
 });
+
+# Ensure manual excerpts are trimmed to the default 55 words
+add_filter('get_the_excerpt', function ($excerpt) {
+	return wp_trim_words($excerpt, 55, ' …');
+});


### PR DESCRIPTION
## Description 

Adds a filter to apply `wp_trim_words()` to all excerpts, including manually written ones, to ensure a consistent word limit of 55 words across the site.

Related Slack discussion thread: https://dxw.slack.com/archives/C04AJM8DCRF/p1750852653200699?thread_ts=1750841771.312749&cid=C04AJM8DCRF

## How to Test
1. Ensure both Post Indexer and dxw Private by Default plugins are Network activated
2. Click the Open/Restricted toggle button on the right-hand side of the network sites list http://localhost/wp-admin/network/sites.php
3. Create a Post on a child site
4. Manually ad an excerpt [Screen Options -> Check the Excerpt box]
5. Add a very long excerpt
6. Go to the child site home page
7. Confirm the excerpt is truncated
8. Go to the parent site
9. Ensure a page exists with the `all-posts` slug and that it uses the `All Posts` template
10. Confirm the excerpt is truncated on http://localhost/all-posts/

## Screenshots
**Before**
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/1e5fedaf-90b2-4d76-aa26-d1e043e820dc" />


**After**
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/0db85321-ef21-4292-96f0-1904e45daf2a" />