### PR TITLE
Remove extra search box from 404 page

### DIFF
--- a/templates/404.php
+++ b/templates/404.php
@@ -2,11 +2,8 @@
 
 <h1 class="govuk-heading-l">Sorry, but the page you were trying to view does not exist.</h1>
 
-
 <p class="govuk-body"><?php _e('It looks like this was the result of either:', 'roots'); ?></p>
 <ul class="govuk-list govuk-list--bullet">
   <li><?php _e('a mistyped address', 'roots'); ?></li>
   <li><?php _e('an out-of-date link', 'roots'); ?></li>
 </ul>
-
-<?php get_search_form(); ?>


### PR DESCRIPTION
The styled 404 page aleady has a search box.

Remove this additional one.