### PR TITLE
Use colon in the header name

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -9,9 +9,9 @@ $headerTag = is_home() ? 'h1' : 'div';
 
         <div class="govuk-grid-column-two-thirds">
             <<?php echo $headerTag; ?> class="blog-title govuk-heading-xl">
-                <span class="blog"><a href="<?php echo network_site_url(); ?>">Blog</a></span>
-                <a href="<?php echo home_url() ?>"><?php bloginfo('name') ?></a>
-			</<?php echo $headerTag; ?>>
+                <span class="blog"><a href="<?php echo network_site_url(); ?>">Blog</a></span><span class="govuk-visually-hidden">:</span>
+                <a href="<?php echo home_url(); ?>"><?php bloginfo('name'); ?></a>
+            </<?php echo $headerTag; ?>>
 
             <?php if ($orgs = gds_organisations() ||  get_option('options_gds_location')) : ?>
                 <div class="bottom blog-meta">


### PR DESCRIPTION
The semantic value of the blog title in H1 should contain a colon where separate parts are not visually distinguishable.

```
<h1>Blog Civil Service</h1>
```

```
<h1>Blog: Civil Service</h1>
```