### PR TITLE
Don't redefine constants

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -18,9 +18,13 @@
  */
 
 # Note: GDS can't use this because of special embed code for Analytics. See lib/scripts.php.
-define('GOOGLE_ANALYTICS_ID', ''); // UA-XXXXX-Y
+if (!defined('GOOGLE_ANALYTICS_ID')) {
+	define('GOOGLE_ANALYTICS_ID', ''); // UA-XXXXX-Y
+}
 
-define('POST_EXCERPT_LENGTH', 40);
+if (!defined('POST_EXCERPT_LENGTH')) {
+	define('POST_EXCERPT_LENGTH', 40);
+}
 
 /**
  * $content_width is a global variable used by WordPress for max image upload sizes


### PR DESCRIPTION
If you could redefine a constant it would be a variable.

If the intention of the code is to replace an existing constant, it can't work.

Therefore the only reasonable interpretation is that the code exists just to ensure the constant exists, even if empty.

```
PHP Warning:  Constant GOOGLE_ANALYTICS_ID already defined in /var/www/html/wp-content/themes/gds-blogs/lib/config.php on line 21
```